### PR TITLE
Add Symfony Cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
 		"wmde/fun-validators": "~3.0.0"
 	},
 	"require-dev": {
+		"symfony/cache": "^5.3",
 		"phpunit/phpunit": "~9.5.1",
 		"wmde/fundraising-phpcs": "~3.0",
 		"phpstan/phpstan": "~0.11"


### PR DESCRIPTION
Doctrine v2.9 removed the internal caching so we now need to use the Symfony one