### PR TITLE
Make dependencies compatible with PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 
 		"doctrine/orm": "~2.7",
 		"gedmo/doctrine-extensions": "^3.0",
-		"psr/log": "~1.0",
+		"psr/log": "^1.0|^2.0|^3.0",
 
 		"wmde/email-address": "~1.0",
 		"wmde/fun-validators": "~4.0"
@@ -15,8 +15,8 @@
 	"require-dev": {
 		"symfony/cache": "^5.3",
 		"phpunit/phpunit": "~9.5.1",
-		"wmde/fundraising-phpcs": "~3.0",
-		"phpstan/phpstan": "~1.0"
+		"wmde/fundraising-phpcs": "~7.0",
+		"phpstan/phpstan": "~1.7"
 	},
 	"repositories": [
 		{
@@ -43,6 +43,11 @@
 	"extra": {
 		"branch-alias": {
 			"dev-master": "0.1.x-dev"
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/package-versions-deprecated": true
 		}
 	}
 }

--- a/tests/Integration/DataAccess/DoctrineSubscriptionRepositoryTest.php
+++ b/tests/Integration/DataAccess/DoctrineSubscriptionRepositoryTest.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\SubscriptionContext\Tests\Integration\DataAccess;
 
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\ORMException;
 use Doctrine\Persistence\ObjectRepository;
 use PHPUnit\Framework\TestCase;
@@ -16,9 +15,6 @@ use WMDE\Fundraising\SubscriptionContext\Tests\TestEnvironment;
 
 /**
  * @covers \WMDE\Fundraising\SubscriptionContext\DataAccess\DoctrineSubscriptionRepository
- *
- * @license GPL-2.0-or-later
- * @author Gabriel Birke < gabriel.birke@wikimedia.de >
  */
 class DoctrineSubscriptionRepositoryTest extends TestCase {
 


### PR DESCRIPTION
psr/log must be 2.0 or 3.0 for PHP 8.1, because it has added types.

Update coding style and PHPStan