### PR TITLE
Modernize Doctrine initialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 8.0
+  - 8.1
 
 sudo: false
 
@@ -14,7 +14,7 @@ install:
 script:
   - make ci-with-coverage COVERAGE_FLAGS="--coverage-clover coverage.clover"
   - make install-php COMPOSER_FLAGS="--no-dev -q" # Remove dev dependencies to make sure PHPStan creates errors if prod code depends on dev classes
-  - docker run -v $PWD:/app --rm ghcr.io/phpstan/phpstan analyse --level 1 --no-progress src/ # Can't use "make stan" because stan was removed
+  - docker run -v $PWD:/app --rm ghcr.io/phpstan/phpstan:1-php8.1 analyse --level 1 --no-progress src/ # Can't use "make stan" because stan was removed
 
 after_success:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"license": "GPL-2.0-or-later",
 	"description": "Bounded Context for fundraising subcriptions",
 	"require": {
-		"php": ">=8.0",
+		"php": ">=8.1",
 
 		"doctrine/orm": "~2.7",
 		"gedmo/doctrine-extensions": "^3.0",

--- a/src/SubscriptionContextFactory.php
+++ b/src/SubscriptionContextFactory.php
@@ -5,24 +5,17 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\SubscriptionContext;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\ORM\Mapping\Driver\XmlDriver;
-use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Gedmo\Timestampable\TimestampableListener;
 
 class SubscriptionContextFactory {
 
-	/**
-	 * Use this constant for MappingDriverChain::addDriver
-	 */
-	public const ENTITY_NAMESPACE = 'WMDE\Fundraising\SubscriptionContext\Domain\Model';
-
 	private const DOCTRINE_CLASS_MAPPING_DIRECTORY = __DIR__ . '/../config/DoctrineClassMapping';
 
-	public function newMappingDriver(): MappingDriver {
-		// We're only calling this for the side effect of adding Mapping/Driver/DoctrineAnnotations.php
-		// to the AnnotationRegistry. When AnnotationRegistry is deprecated with Doctrine Annotations 2.0,
-		// use $this->annotationReader instead
-		return new XmlDriver( self::DOCTRINE_CLASS_MAPPING_DIRECTORY );
+	/**
+	 * @return string[]
+	 */
+	public function getDoctrineMappingPaths(): array {
+		return [ self::DOCTRINE_CLASS_MAPPING_DIRECTORY ];
 	}
 
 	public function newEventSubscribers(): array {

--- a/tests/TestEnvironment.php
+++ b/tests/TestEnvironment.php
@@ -6,7 +6,8 @@ namespace WMDE\Fundraising\SubscriptionContext\Tests;
 
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Tools\Setup;
+use Doctrine\ORM\ORMSetup;
+use WMDE\Fundraising\SubscriptionContext\SubscriptionContextFactory;
 
 /**
  * @license GPL-2.0-or-later
@@ -21,6 +22,7 @@ class TestEnvironment {
 	}
 
 	public static function newInstance(): self {
+		$subscriptionContextFactory = new SubscriptionContextFactory();
 		$environment = new self(
 			[
 				'db' => [
@@ -29,7 +31,7 @@ class TestEnvironment {
 				],
 				'var-path' => '/tmp'
 			],
-			Setup::createConfiguration( true )
+			ORMSetup::createXMLMetadataConfiguration( $subscriptionContextFactory->getDoctrineMappingPaths() )
 		);
 		$environment->install();
 		return $environment;

--- a/tests/TestSubscriptionContextFactory.php
+++ b/tests/TestSubscriptionContextFactory.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\SubscriptionContext\Tests;
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
@@ -29,13 +28,9 @@ class TestSubscriptionContextFactory {
 
 	public function getEntityManager(): EntityManager {
 		if ( $this->entityManager === null ) {
-			AnnotationRegistry::registerLoader( 'class_exists' );
-
-			$this->doctrineConfig->setMetadataDriverImpl( $this->factory->newMappingDriver() );
-
 			$eventManager = $this->setupEventSubscribers( $this->factory->newEventSubscribers() );
 
-			$this->entityManager = EntityManager::create(
+			$this->entityManager = new EntityManager(
 				$this->connection,
 				$this->doctrineConfig,
 				$eventManager
@@ -46,7 +41,7 @@ class TestSubscriptionContextFactory {
 	}
 
 	private function setupEventSubscribers( array $eventSubscribers ): EventManager {
-		$eventManager = $this->connection->getEventManager();
+		$eventManager = new EventManager();
 		foreach ( $eventSubscribers as $eventSubscriber ) {
 			$eventManager->addEventSubscriber( $eventSubscriber );
 		}


### PR DESCRIPTION
Implement more modern Doctrine initialization in
TestSubscriptionContextFactory, removing deprecated and dropped methods

Change interface of SubscriptionContextFactory. This is a BC break, but the dependents of this bounded context are ready for it, so not breakage will occur when (auto)updating to a new release.

Ticket: https://phabricator.wikimedia.org/T312080