### PR TITLE
Remove Symfony Cache dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
 		"wmde/fun-validators": "~4.0"
 	},
 	"require-dev": {
-		"symfony/cache": "^5.3",
 		"phpunit/phpunit": "~10.0.7",
 		"wmde/fundraising-phpcs": "~7.0",
 		"phpstan/phpstan": "~1.7"


### PR DESCRIPTION
The cache class is not used anywhere (explicitly), so we can remove the explicit dependency.