### PR TITLE
Fix and improve CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ composer.lock
 .phpunit.result.cache
 .phpunit.cache
 
+.deptrac.cache
+
 vendor/
 coverage/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ install:
 
 script:
   - make ci-with-coverage COVERAGE_FLAGS="--coverage-clover coverage.clover"
-  - make install-php COMPOSER_FLAGS="--no-dev -q" # Remove dev dependencies to make sure PHPStan creates errors if prod code depends on dev classes
-  - docker run -v $PWD:/app --rm registry.gitlab.com/fun-tech/fundraising-frontend-docker:stan analyse --level 9 --no-progress src/ # Can't use "make stan" because stan was removed
 
 after_success:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: php
 
-php:
-  - 8.1
+dist: bionic
 
-sudo: false
+php:
+  - 8.2
 
 services:
   - docker
 
 install:
-  - travis_retry make setup
+  - travis_retry composer install --prefer-dist --no-interaction
 
 script:
   - make ci-with-coverage COVERAGE_FLAGS="--coverage-clover coverage.clover"

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ fix-cs:
 	docker-compose run --rm --no-deps app ./vendor/bin/phpcbf
 
 stan:
-	docker-compose run --rm --no-deps app ./vendor/bin/phpstan analyse --level=9 -c phpstan.neon --no-progress src/ tests/
+	docker-compose run --rm --no-deps app ./vendor/bin/phpstan analyse --level=9 --no-progress src/ tests/
 
 setup: install-php
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,15 @@ DOCKER_FLAGS   := --interactive --tty
 DOCKER_IMAGE   := registry.gitlab.com/fun-tech/fundraising-frontend-docker
 COVERAGE_FLAGS := --coverage-html coverage
 
+# Show progress in shell environment, hide progress in CI environment
+ifndef CI
+progress_opts :=
+phpcs_progress_opts :=
+else
+progress_opts := --no-progress
+phpcs_progress_opts := -p
+endif
+
 install-php:
 	docker run --rm $(DOCKER_FLAGS) --volume $(BUILD_DIR):/app -w /app --volume ~/.composer:/composer --user $(current_user):$(current_group) $(DOCKER_IMAGE):composer composer install $(COMPOSER_FLAGS)
 
@@ -18,22 +27,22 @@ ci-with-coverage: phpunit-with-coverage cs stan architecture-check
 test: phpunit
 
 phpunit:
-	docker-compose run --rm --no-deps app ./vendor/bin/phpunit
+	docker-compose run --rm --no-deps app ./vendor/bin/phpunit $(progress_opts)
 
 phpunit-with-coverage:
-	docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --rm --no-deps -e XDEBUG_MODE=coverage app_debug ./vendor/bin/phpunit $(COVERAGE_FLAGS)
+	docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --rm --no-deps -e XDEBUG_MODE=coverage app_debug ./vendor/bin/phpunit $(COVERAGE_FLAGS) $(progress_opts)
 
 cs:
-	docker-compose run --rm --no-deps app ./vendor/bin/phpcs
+	docker-compose run --rm --no-deps app ./vendor/bin/phpcs $(phpcs_progress_opts)
 
 fix-cs:
 	docker-compose run --rm --no-deps app ./vendor/bin/phpcbf
 
 stan:
-	docker-compose run --rm --no-deps app ./vendor/bin/phpstan analyse --level=9 --no-progress src/ tests/
+	docker-compose run --rm --no-deps app ./vendor/bin/phpstan analyse --level=9 $(progress_opts) src/ tests/
 
 architecture-check:
-	docker-compose run --rm --no-deps app ./vendor/bin/deptrac analyse --fail-on-uncovered --report-uncovered
+	docker-compose run --rm --no-deps app ./vendor/bin/deptrac analyse $(progress_opts) --fail-on-uncovered --report-uncovered
 
 
 setup: install-php

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ install-php:
 update-php:
 	docker run --rm $(DOCKER_FLAGS) --volume $(BUILD_DIR):/app -w /app --volume ~/.composer:/composer --user $(current_user):$(current_group) $(DOCKER_IMAGE):composer composer update $(COMPOSER_FLAGS)
 
-ci: phpunit cs stan
+ci: phpunit cs stan architecture-check
 
-ci-with-coverage: phpunit-with-coverage cs stan
+ci-with-coverage: phpunit-with-coverage cs stan architecture-check
 
 test: phpunit
 
@@ -32,6 +32,10 @@ fix-cs:
 stan:
 	docker-compose run --rm --no-deps app ./vendor/bin/phpstan analyse --level=9 --no-progress src/ tests/
 
+architecture-check:
+	docker-compose run --rm --no-deps app ./vendor/bin/deptrac analyse --fail-on-uncovered --report-uncovered
+
+
 setup: install-php
 
-.PHONY: install-php update-php ci ci-with-coverage test phpunit phpunit-with-coverage cs fix-cs stan setup
+.PHONY: install-php update-php ci ci-with-coverage test phpunit phpunit-with-coverage cs fix-cs stan setup architecture-check

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
 		"phpunit/phpunit": "~10.1.1",
 		"wmde/fundraising-phpcs": "~8.0",
 		"phpstan/phpstan": "~1.7",
-		"symfony/cache": "^6.1"
+		"symfony/cache": "^6.1",
+		"qossmic/deptrac-shim": "^1.0"
 	},
 	"repositories": [
 		{

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -1,0 +1,82 @@
+deptrac:
+  paths:
+    - ./src
+  exclude_files:
+    - '#.*tests.*#'
+  layers:
+    - name: Domain
+      collectors:
+        - type: classLike
+          value: WMDE\\Fundraising\\SubscriptionContext\\Domain\\.*
+    - name: UseCase
+      collectors:
+        - type: classLike
+          value: WMDE\\Fundraising\\SubscriptionContext\\UseCases.*
+    - name: DomainValidators
+      collectors:
+        - type: classLike
+          value: WMDE\\Fundraising\\SubscriptionContext\\Validation.*
+
+    - name: DataAccess
+      collectors:
+        - type: classLike
+          value: WMDE\\Fundraising\\SubscriptionContext\\DataAccess.*
+    - name: ServiceInterface
+      collectors:
+        - type: interface
+          value: WMDE\\Fundraising\\SubscriptionContext\\Services.*
+        - type: interface
+          value: WMDE\\Fundraising\\SubscriptionContext\\Infrastructure.*
+    - name: Service
+      collectors:
+        - type: class
+          value: WMDE\\Fundraising\\SubscriptionContext\\Services.*
+    # Domain libraries from WMDE
+    - name: DomainLibrary
+      collectors:
+        - type: classNameRegex
+          value: /WMDE\\EmailAddress\\EmailAddress/
+        - type: classNameRegex
+          value: /WMDE\\FunValidators\\.*/
+    # External Vendor libraries
+    - name: Doctrine
+      collectors:
+        - type: classNameRegex
+          value: /Doctrine\\.*/
+  ruleset:
+    Domain:
+      - DomainLibrary
+    DomainValidators:
+      - Domain
+      - DomainLibrary
+    UseCase:
+      - Domain
+      - DataAccess
+      - ServiceInterface
+      - DomainLibrary
+      - DomainValidators
+    DataAccess:
+      - Domain
+      - DomainLibrary
+      - Doctrine
+    Service:
+      - DomainLibrary
+      - Domain
+      - DataAccess
+      - ServiceInterface
+      - Doctrine
+    ServiceInterface:
+      - Domain
+      - DomainLibrary
+  formatters:
+    graphviz:
+      groups:
+        Service:
+          - Service
+          - ServiceInterface
+        Vendor:
+          - Doctrine
+          - Guzzle
+          - Sofort
+
+

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,0 @@
-parameters:
-	ignoreErrors:
-		-
-			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
-			count: 1
-			path: src/DataAccess/DoctrineSubscriptionRepository.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,0 @@
-includes:
-	- phpstan-baseline.neon


### PR DESCRIPTION
- Use Travis composer to install dependencies, update `.travis` file
- Remove PHPStan ignore rule that's no longer necessary with latest release of Doctrine ORM
- Add architecture check to further simplify `.travis` file
- Improve Makefile to show tool progress when we're running it on our local machines 