### PR TITLE
Turn off dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,5 @@ updates:
       interval: "daily"
     reviewers:
       - "wmde/funtech-core"
-      
+    # Turn off dependabot until we move CI from Travis to Drone
+    open-pull-requests-limit: 0


### PR DESCRIPTION
This should be reactivated when we move CI from Travis to Drone