### PR TITLE
Remove coverage upload to Scrutinizer

### DIFF
--- a/.woodpecker/ci.yml
+++ b/.woodpecker/ci.yml
@@ -30,6 +30,4 @@ steps:
       - vendor/bin/phpcs
       - php -d xdebug.mode=coverage vendor/bin/phpunit --coverage-clover coverage.xml
       - php -d memory_limit=1G vendor/bin/phpstan analyse --level=9 --no-progress src/ tests/
-      # Upload coverage to Scrutinizer
-      - ocular code-coverage:upload --no-interaction --format=php-clover coverage.xml
 


### PR DESCRIPTION
We have removed Scrutinizer and forgot to delete the coverage upload.
This makes all CI runs fail because Scrutinizer no longer recognizes the
repository

There are currently no specific plans to log coverage
